### PR TITLE
Fix string parse, and remove .to_string() from comparisons

### DIFF
--- a/src/query/interpreter.rs
+++ b/src/query/interpreter.rs
@@ -68,7 +68,7 @@ fn _eval_binary_expr(
                     .expect("Not a Number")
                     == right.parse::<f64>().expect("Not a Number"),
             ),
-            _ => RuntimeType::Bool(get_value_from_obj(obj, left).to_string() == right.to_string()),
+            _ => RuntimeType::Bool(get_value_from_obj(obj, left) == right),
         },
         ">" => match right_node_type {
             LiteralType::NumericLiteral => RuntimeType::Bool(
@@ -118,7 +118,7 @@ fn _eval_binary_expr(
                     .expect("Not a Number")
                     != right.parse::<f64>().expect("Not a Number"),
             ),
-            _ => RuntimeType::Bool(get_value_from_obj(obj, left).to_string() != right.to_string()),
+            _ => RuntimeType::Bool(get_value_from_obj(obj, left) != right),
         },
         _ => RuntimeType::Bool(false),
     }

--- a/src/query/lexer.rs
+++ b/src/query/lexer.rs
@@ -51,12 +51,10 @@ pub(super) fn tokenize(source_string: &str) -> VecDeque<Token> {
         {
             cursor += val.len();
             tokens.push_back(Token::new(TokenType::String, val.to_string()));
-        } else if let Some(val) = MATCH_STRING
-            .find(&source_string[cursor..])
-            .map(|x| x.as_str().replace("'", "\""))
-        {
-            cursor += val.len();
-            tokens.push_back(Token::new(TokenType::String, val));
+        } else if let Some(cap) = MATCH_STRING.captures(&source_string[cursor..]) {
+            let (full, [val]) = cap.extract();
+            cursor += full.len();
+            tokens.push_back(Token::new(TokenType::String, val.to_string()));
         } else if let Some(val) = MATCH_BINARY_OPERATOR
             .find(&source_string[cursor..])
             .map(|x| x.as_str())

--- a/src/query/lexer.rs
+++ b/src/query/lexer.rs
@@ -23,16 +23,11 @@ impl Token {
 }
 
 static MATCH_NUMBER: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^\d+\.?\d+").unwrap());
-
-static MATCH_FIELD_STRING: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9._]+").unwrap());
-
+static MATCH_IDENT: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9._]+").unwrap());
 static MATCH_STRING: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#"^'(.*?)'"#).unwrap());
-
 static MATCH_BINARY_OPERATOR: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"^(^(!=)|^(<=)|^(>=)|^(=)|^(<)|^(>)|^(&&)|^(\|\|)|^(\+)|^(-))").unwrap()
 });
-
 static MATCH_PAREN: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^[()]").unwrap());
 
 pub(super) fn tokenize(source_string: &str) -> VecDeque<Token> {
@@ -45,7 +40,7 @@ pub(super) fn tokenize(source_string: &str) -> VecDeque<Token> {
         {
             cursor += val.len();
             tokens.push_back(Token::new(TokenType::Number, val.to_string()));
-        } else if let Some(val) = MATCH_FIELD_STRING
+        } else if let Some(val) = MATCH_IDENT
             .find(&source_string[cursor..])
             .map(|x| x.as_str())
         {


### PR DESCRIPTION
I found the problem.
It turns out you were not removing the double quotes `"` from the token String. But I see you had thought about that because you included parenthesis (capture groups) in the regex, only forgot to use it or didn't know how:
https://github.com/mainak55512/rjq/blob/1b98ebec64ad421f1b45f64db8ad5313634b64c4/src/query/lexer.rs#L30

This fix uses the capture groups you intended, simplifies the code around it, and removes the last clippy warnings again.